### PR TITLE
Tweak email notifications

### DIFF
--- a/apiserver/plane/app/views/notification/base.py
+++ b/apiserver/plane/app/views/notification/base.py
@@ -342,8 +342,15 @@ class UserNotificationPreferenceEndpoint(BaseAPIView):
 
     # request the object
     def get(self, request):
-        user_notification_preference = UserNotificationPreference.objects.get(
-            user=request.user
+        user_notification_preference, created = UserNotificationPreference.objects.get_or_create(
+            user=request.user,
+            defaults={
+                'property_change': False,
+                'state_change': False,
+                'comment': False,
+                'mention': False,
+                'issue_completed': False,
+            }
         )
         serializer = UserNotificationPreferenceSerializer(user_notification_preference)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apiserver/plane/celery.py
+++ b/apiserver/plane/celery.py
@@ -28,9 +28,9 @@ app.conf.beat_schedule = {
         "task": "plane.bgtasks.file_asset_task.delete_unuploaded_file_asset",
         "schedule": crontab(hour=0, minute=0),
     },
-    "check-every-five-minutes-to-send-email-notifications": {
+    "check-every-minutes-to-send-email-notifications": {
         "task": "plane.bgtasks.email_notification_task.stack_email_notification",
-        "schedule": crontab(minute="*/5"),
+        "schedule": crontab(minute="*/1"),
     },
     "check-every-day-to-delete-hard-delete": {
         "task": "plane.bgtasks.deletion_task.hard_delete",


### PR DESCRIPTION
### Description

This PR introduces two key improvements to our notification system:

1. Adds default notification preferences for new users
2. Increases email notification frequency for more timely updates

### Changes

#### User Notification Preferences
- Modified `UserNotificationPreferenceEndpoint.get()` to use `get_or_create()`
- Added default preferences for new users with all notifications disabled by default:
  - Property changes: disabled
  - State changes: disabled
  - Comments: disabled
  - Mentions: disabled
  - Issue completions: disabled

#### Email Notification Frequency
- Changed email notification check frequency from every 5 minutes to every minute
- Updated celery task name to reflect new timing
- Task: `stack_email_notification` will now run more frequently